### PR TITLE
Add manual trigger and full pipeline logic to GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,7 +246,7 @@ jobs:
     outputs:
       image_tag: ${{ github.run_number }} # output the image tag to be used in the build-and-publish-docker-image job
     needs: [build, test] # depend on the build job to get the published app artifact
-    if: github.event.inputs.full_pipeline && (github.event_name == 'push' || (github.event_name == 'pull_request_target' && github.base_ref == 'main' && github.head_ref == 'develop'))
+    if: ${{ github.event.inputs.full_pipeline && (github.event_name == 'push' || (github.event_name == 'pull_request_target' && github.base_ref == 'main' && github.head_ref == 'develop')) }}
     permissions:
       packages: write
       id-token: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,12 @@ on:
         description: 'Run the pipeline with debug deployment enabled'
         required: false
         default: 'false'
+      full_pipeline:
+        type: boolean
+        description: 'Run the full pipeline to production'
+        required: false
+        default: false
+
   push:
     branches:
       - main
@@ -240,7 +246,7 @@ jobs:
     outputs:
       image_tag: ${{ github.run_number }} # output the image tag to be used in the build-and-publish-docker-image job
     needs: [build, test] # depend on the build job to get the published app artifact
-    if: github.event_name == 'push' || (github.event_name == 'pull_request_target' && github.base_ref == 'main' && github.head_ref == 'develop')
+    if: github.event.inputs.full_pipeline && (github.event_name == 'push' || (github.event_name == 'pull_request_target' && github.base_ref == 'main' && github.head_ref == 'develop'))
     permissions:
       packages: write
       id-token: write
@@ -277,6 +283,7 @@ jobs:
 
   deploy:
     needs: [build-and-publish-docker-image] # this job needs build-and-publish-docker-image job as a requirement to run
+    if: ${{ github.event.inputs.full_pipeline }}
     uses: ./.github/workflows/cd.yml
     with:
       # with tag from the build-and-publish-docker-image job in the output_tags step


### PR DESCRIPTION
### Summary

This pull request introduces the following changes:

1. **Manual Trigger for Full Pipeline**: Added a `workflow_dispatch` event to the GitHub Actions workflow, allowing manual triggering of the pipeline.
2. **Full Pipeline Logic**: Incorporated conditional logic to ensure the pipeline behaves differently based on the `full_pipeline` input.

These changes enable running the full pipeline all the way to production on a manual trigger.